### PR TITLE
Underline styles for anchor

### DIFF
--- a/dist/kks.css
+++ b/dist/kks.css
@@ -39,11 +39,23 @@ nav .no-background {
 
 .wp-block-navigation a:where(:not(.wp-element-button)) {
   text-underline-offset: 0.3rem;
-  text-decoration: underline;
+  -webkit-text-decoration: underline dotted;
+  text-decoration: underline dotted;
   font-weight: 400;
 }
 .wp-block-navigation a:where(:not(.wp-element-button)):hover {
   text-underline-offset: 0.3rem;
+}
+
+a {
+  -webkit-text-decoration: underline dotted;
+  text-decoration: underline dotted;
+  text-decoration-color: var(--wp--preset--color--main);
+}
+a:hover, a:focus {
+  -webkit-text-decoration: underline dotted;
+  text-decoration: underline dotted;
+  text-decoration-color: var(--wp--preset--color--main);
 }
 
 a:where(:not(.wp-element-button)) {
@@ -55,6 +67,8 @@ a:where(:not(.wp-element-button)):where(.product-btn, .resourse-btn) {
   font-size: var(--wp--preset--font-size--small);
   font-weight: bold;
   white-space: nowrap;
+  -webkit-text-decoration: underline dotted;
+  text-decoration: underline dotted;
 }
 a:where(:not(.wp-element-button)):where(.product-btn, .resourse-btn):hover {
   color: var(--wp--preset--color--main);

--- a/scss/kks.scss
+++ b/scss/kks.scss
@@ -48,11 +48,25 @@ nav {
 
 .wp-block-navigation a:where(:not(.wp-element-button)) {
     text-underline-offset: 0.3rem;
-    text-decoration: underline;
+    -webkit-text-decoration: underline dotted;
+            text-decoration: underline dotted;
     font-weight: 400;
 
     &:hover {
         text-underline-offset: 0.3rem;
+    }
+}
+
+a {
+    -webkit-text-decoration: underline dotted;
+        text-decoration: underline dotted;
+        -webkit-text-decoration-color: var(--wp--preset--color--main);
+        text-decoration-color: var(--wp--preset--color--main);
+    &:hover, &:focus {
+        -webkit-text-decoration: underline dotted;
+                text-decoration: underline dotted;
+        -webkit-text-decoration-color: var(--wp--preset--color--main);
+                text-decoration-color: var(--wp--preset--color--main);
     }
 }
 
@@ -64,6 +78,8 @@ a:where(:not(.wp-element-button)) {
         font-size: var(--wp--preset--font-size--small);
         font-weight: bold;
         white-space: nowrap;
+        -webkit-text-decoration: underline dotted;
+                text-decoration: underline dotted;
 
         &:hover {
             color: var(--wp--preset--color--main);


### PR DESCRIPTION
- Replace underline with underline dotted
- Apply at anchor and `:focus`, and `:hover`